### PR TITLE
fix: prettier special folder names

### DIFF
--- a/plugins/prettier-plugin.js
+++ b/plugins/prettier-plugin.js
@@ -35,9 +35,12 @@ exports.prettierPlugin = async () => {
   }
 
   try {
-    execSync(`prettier --check ${filteredFiles.join(" ")}`, {
-      encoding: "utf8",
-    });
+    execSync(
+      `prettier --check ${filteredFiles.map((file) => `"${file}"`).join(" ")}`,
+      {
+        encoding: "utf8",
+      },
+    );
     message("Prettier check success :clap:", { icon: ":white_check_mark:" });
   } catch (error) {
     const errorLines = error.stdout.split("\n");


### PR DESCRIPTION
**Bug**
When folder names have () in the name for example when using expo projects.
Prettier plugin failed  `/bin/sh: 1: Syntax error: "(" unexpected` 

**Fix**
Make sure pettier uses quoted files paths to not break when folder has special chars like ( ) in the name
