### PR TITLE
fix: use setup-node managed .npmrc for npm authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,14 +40,10 @@ jobs:
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
-      - name: NPM Credentials
-        run: npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Install dependencies
         run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Release
         run: npm run release -- --ci -V --increment $TYPE_ARG $DRY_ARG
@@ -55,5 +51,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_PUSH_TOKEN }}
           TYPE_ARG: ${{ inputs.type }}
           DRY_ARG: ${{ inputs.dry == true && '--dry-run' || '' }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Before: The token was set via npm config set (writing directly to ~/.npmrc) and also passed as both NPM_TOKEN and NODE_AUTH_TOKEN env vars.


After: The token is passed only as NODE_AUTH_TOKEN, which is the env var that the setup-node-generated .npmrc references.