### PR TITLE
feat: oxc (oxlint + oxfmt) support + graceful ESLint skip on config-less repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,14 @@ on:
         type: boolean
         description: Dry run release
         default: false
+      preRelease:
+        type: choice
+        description: "Prerelease channel (none = stable latest tag)"
+        options:
+          - none
+          - beta
+        required: true
+        default: none
 
 jobs:
   publish:
@@ -50,10 +58,11 @@ jobs:
         run: npm ci
 
       - name: Release
-        run: npm run release -- --ci -V --increment $TYPE_ARG $DRY_ARG
+        run: npm run release -- --ci -V --increment $TYPE_ARG $PRE_ARG $DRY_ARG
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PUSH_TOKEN }}
           TYPE_ARG: ${{ inputs.type }}
+          PRE_ARG: ${{ inputs.preRelease == 'beta' && '--preRelease=beta' || '' }}
           DRY_ARG: ${{ inputs.dry == true && '--dry-run' || '' }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -19,15 +19,20 @@ npm install --save-dev @novemberfiveco/highvoltage-js
 
 ## Batteries included
 
-The following checks are performed in the following order
+The following checks are performed in the following order. The lint/format checks are
+config-agnostic: each one **skips automatically** when its tool isn't part of the project, so
+a repo can be on ESLint + Prettier, on oxc (oxlint + oxfmt), or mid-migration with both.
 
-1. ESLint: ESLint is run on the created / changed files only and will
-   use the projects ESLint configuration
-2. Npm Audit: Npm Audit is run and a summary is printed as a warning
-3. Package Lock consistency: Displays a warning if `package.json` is updated but `package-lock.json` not
-4. Highvoltage version: Npm checks if highvoltage is running on the latest version
-5. Display a message when there are open TODOs found in your PR.
-6. ... your check here!
+1. ESLint: run on the created / changed files only, using the project's ESLint configuration.
+   Skips automatically on projects without a resolvable ESLint config.
+2. Prettier: checks formatting of changed files. Skips automatically when `prettier` is not a project dependency.
+3. oxlint: lints created / changed files using the project's `.oxlintrc.json`. Skips automatically when `oxlint` is not a project dependency.
+4. oxfmt: checks formatting of changed files. Skips automatically when `oxfmt` is not a project dependency.
+5. Npm Audit: Npm Audit is run and a summary is printed as a warning
+6. Package Lock consistency: Displays a warning if `package.json` is updated but `package-lock.json` not
+7. Highvoltage version: Npm checks if highvoltage is running on the latest version
+8. Display a message when there are open TODOs found in your PR.
+9. ... your check here!
 
 ## Running on CI
 

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -3,6 +3,8 @@ import { schedule } from "danger";
 
 const { eslintPlugin } = require("./plugins/eslint-plugin");
 const { prettierPlugin } = require("./plugins/prettier-plugin");
+const { oxlintPlugin } = require("./plugins/oxlint-plugin");
+const { oxfmtPlugin } = require("./plugins/oxfmt-plugin");
 const { npmAuditPlugin } = require("./plugins/npm-audit-plugin");
 const { packageLockPlugin } = require("./plugins/package-lock-plugin");
 const {
@@ -10,11 +12,17 @@ const {
 } = require("./plugins/highvoltage-outdated-plugin");
 const { todoPlugin } = require("./plugins/todo-plugin");
 
-// Run ESLint
+// Run ESLint (skips automatically on projects without an ESLint config)
 schedule(eslintPlugin());
 
-// Run Prettier
+// Run Prettier (skips automatically when prettier is not a project dependency)
 schedule(prettierPlugin());
+
+// Run oxlint (skips automatically when oxlint is not a project dependency)
+schedule(oxlintPlugin());
+
+// Run oxfmt (skips automatically when oxfmt is not a project dependency)
+schedule(oxfmtPlugin());
 
 // Run NPM audit
 schedule(npmAuditPlugin());

--- a/plugins/eslint-plugin.js
+++ b/plugins/eslint-plugin.js
@@ -20,7 +20,7 @@ exports.eslintPlugin = async () => {
   const filesToLint = git.created_files.concat(git.modified_files);
   // Eslint extension list only works for directories so do it ourselfs
   const filteredFiles = filesToLint.filter(
-    (file) => !!file.match("(tsx|ts|js)$"),
+    (file) => !!file.match(/\.(tsx|ts|js)$/),
   );
 
   if (filteredFiles.length === 0) {

--- a/plugins/eslint-plugin.js
+++ b/plugins/eslint-plugin.js
@@ -4,6 +4,16 @@ const Path = require("path");
 const { git } = danger;
 
 /**
+ * ESLint 9 throws when a repo has no resolvable config (the post-migration,
+ * oxc-only state). Detect that specific failure so we can skip gracefully
+ * instead of crashing the whole Danger run. Any other error must still surface.
+ */
+const isMissingConfigError = (error) =>
+  /could not find.*config|couldn't find.*config|no eslint configuration/i.test(
+    (error && error.message) || "",
+  );
+
+/**
  * Eslint your code with Danger, this only lints created / changed files
  */
 exports.eslintPlugin = async () => {
@@ -12,9 +22,24 @@ exports.eslintPlugin = async () => {
   const filteredFiles = filesToLint.filter(
     (file) => !!file.match("(tsx|ts|js)$"),
   );
-  const eslint = new ESLint();
 
-  const results = await eslint.lintFiles(filteredFiles);
+  if (filteredFiles.length === 0) {
+    message("No files to check with ESLint");
+    return;
+  }
+
+  let eslint;
+  let results;
+  try {
+    eslint = new ESLint();
+    results = await eslint.lintFiles(filteredFiles);
+  } catch (error) {
+    if (isMissingConfigError(error)) {
+      message("No ESLint config found in project, skipping ESLint check");
+      return;
+    }
+    throw error;
+  }
 
   let failed = false;
 
@@ -27,7 +52,7 @@ exports.eslintPlugin = async () => {
       if (msg.fatal) {
         fail(`Fatal error linting ${path} with eslint.`, path, 1);
       } else {
-        const fn = { 1: warn, 2: fail }[msg.severity];
+        const fn = { 1: warn, 2: fail }[msg.severity] ?? warn;
         fn(`${msg.message} (${msg.ruleId})`, path, msg.line);
       }
     }

--- a/plugins/oxfmt-plugin.js
+++ b/plugins/oxfmt-plugin.js
@@ -1,4 +1,4 @@
-const { execSync } = require("child_process");
+const { execFileSync } = require("child_process");
 const Path = require("path");
 
 const { git } = danger;
@@ -36,7 +36,7 @@ exports.oxfmtPlugin = async () => {
   const filesToCheck = git.created_files.concat(git.modified_files);
   const filteredFiles = filesToCheck.filter(
     (file) =>
-      !!file.match("(tsx|ts|jsx|js|mjs|cjs|json|md|yml|yaml|css|scss|html)$"),
+      !!file.match(/\.(tsx|ts|jsx|js|mjs|cjs|json|md|yml|yaml|css|scss|html)$/),
   );
 
   if (filteredFiles.length === 0) {
@@ -44,13 +44,11 @@ exports.oxfmtPlugin = async () => {
     return;
   }
 
-  const quoted = filteredFiles.map((file) => `"${file}"`).join(" ");
-
   try {
     // --list-different prints nothing and exits 0 when everything is formatted;
     // it lists differing files and exits non-zero otherwise. We drive the
     // pass/fail decision off the exit code, not a (fragile) English string.
-    execSync(`oxfmt --list-different ${quoted}`, {
+    execFileSync("oxfmt", ["--list-different", ...filteredFiles], {
       encoding: "utf8",
       env: binEnv(),
     });

--- a/plugins/oxfmt-plugin.js
+++ b/plugins/oxfmt-plugin.js
@@ -48,7 +48,7 @@ exports.oxfmtPlugin = async () => {
     // --list-different prints nothing and exits 0 when everything is formatted;
     // it lists differing files and exits non-zero otherwise. We drive the
     // pass/fail decision off the exit code, not a (fragile) English string.
-    execFileSync("oxfmt", ["--list-different", ...filteredFiles], {
+    execFileSync("oxfmt", ["--list-different", "--", ...filteredFiles], {
       encoding: "utf8",
       env: binEnv(),
     });

--- a/plugins/oxfmt-plugin.js
+++ b/plugins/oxfmt-plugin.js
@@ -1,0 +1,73 @@
+const { execSync } = require("child_process");
+const Path = require("path");
+
+const { git } = danger;
+
+// Ensure the project's local node_modules/.bin is on PATH so `oxfmt` resolves
+// regardless of how Danger was launched.
+const binEnv = () => ({
+  ...process.env,
+  PATH: `${Path.resolve(process.cwd(), "node_modules/.bin")}${Path.delimiter}${process.env.PATH}`,
+});
+
+/**
+ * Check if oxfmt is available in the project.
+ * Mirrors isPrettierInstalled() — the plugin self-skips when oxfmt is unused.
+ */
+const isOxfmtInstalled = () => {
+  try {
+    require.resolve("oxfmt/package.json");
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+
+/**
+ * Check formatting of created / changed files with oxfmt.
+ * oxfmt discovers the project's own .oxfmtrc.json itself.
+ */
+exports.oxfmtPlugin = async () => {
+  if (!isOxfmtInstalled()) {
+    message("oxfmt not found in project dependencies, skipping oxfmt check");
+    return;
+  }
+
+  const filesToCheck = git.created_files.concat(git.modified_files);
+  const filteredFiles = filesToCheck.filter(
+    (file) =>
+      !!file.match("(tsx|ts|jsx|js|mjs|cjs|json|md|yml|yaml|css|scss|html)$"),
+  );
+
+  if (filteredFiles.length === 0) {
+    message("No files to check with oxfmt");
+    return;
+  }
+
+  const quoted = filteredFiles.map((file) => `"${file}"`).join(" ");
+
+  try {
+    // --list-different prints nothing and exits 0 when everything is formatted;
+    // it lists differing files and exits non-zero otherwise. We drive the
+    // pass/fail decision off the exit code, not a (fragile) English string.
+    execSync(`oxfmt --list-different ${quoted}`, {
+      encoding: "utf8",
+      env: binEnv(),
+    });
+    message("oxfmt check success :clap:", { icon: ":white_check_mark:" });
+  } catch (error) {
+    const listed = (error.stdout || "").trim();
+    if (listed) {
+      listed
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .forEach((filePath) => fail(`File is not formatted: \`${filePath}\``));
+    } else if (error.stderr) {
+      fail(`oxfmt error: ${error.stderr.trim()}`);
+    }
+    fail(
+      "oxfmt check failed, please run `oxfmt` (or `npm run format`) to fix formatting issues",
+    );
+  }
+};

--- a/plugins/oxlint-plugin.js
+++ b/plugins/oxlint-plugin.js
@@ -1,0 +1,89 @@
+const { execSync } = require("child_process");
+const Path = require("path");
+
+const { git } = danger;
+
+// Ensure the project's local node_modules/.bin is on PATH so `oxlint` resolves
+// regardless of how Danger was launched (npm run usually adds it; this is belt-and-braces).
+const binEnv = () => ({
+  ...process.env,
+  PATH: `${Path.resolve(process.cwd(), "node_modules/.bin")}${Path.delimiter}${process.env.PATH}`,
+});
+
+/**
+ * Check if oxlint is available in the project.
+ * Mirrors the prettier-plugin's isPrettierInstalled() so HighVoltage stays
+ * config-agnostic: the plugin self-skips on projects that don't use oxlint.
+ */
+const isOxlintInstalled = () => {
+  try {
+    require.resolve("oxlint/package.json");
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+
+/**
+ * Lint created / changed files with oxlint, reporting inline via Danger.
+ * oxlint discovers the project's own .oxlintrc.json itself (same delegation
+ * model as the eslint plugin) — every custom rule/category is respected.
+ */
+exports.oxlintPlugin = async () => {
+  if (!isOxlintInstalled()) {
+    message("oxlint not found in project dependencies, skipping oxlint check");
+    return;
+  }
+
+  const filesToLint = git.created_files.concat(git.modified_files);
+  const filteredFiles = filesToLint.filter(
+    (file) => !!file.match("(tsx|ts|jsx|js|mjs|cjs)$"),
+  );
+
+  if (filteredFiles.length === 0) {
+    message("No files to check with oxlint");
+    return;
+  }
+
+  // oxlint exits non-zero when it finds errors, so capture stdout on both paths.
+  let stdout = "";
+  let stderr = "";
+  try {
+    stdout = execSync(
+      `oxlint --format=json ${filteredFiles.map((f) => `"${f}"`).join(" ")}`,
+      { encoding: "utf8", env: binEnv() },
+    );
+  } catch (error) {
+    stdout = error.stdout || "";
+    stderr = error.stderr || "";
+  }
+
+  let diagnostics = [];
+  try {
+    diagnostics = JSON.parse(stdout).diagnostics || [];
+  } catch (e) {
+    fail(
+      `oxlint produced output that could not be parsed as JSON.${stderr ? ` stderr: ${stderr.trim()}` : ""}`,
+    );
+    return;
+  }
+
+  let failed = false;
+  for (const diag of diagnostics) {
+    const path = diag.filename ? Path.relative(".", diag.filename) : undefined;
+    const span = diag.labels && diag.labels[0] && diag.labels[0].span;
+    const line = span ? span.line : undefined;
+    // Mirror the eslint plugin: any diagnostic fails the check; errors and
+    // warnings are surfaced inline with their matching Danger severity.
+    failed = true;
+    const fn = diag.severity === "error" ? fail : warn;
+    // diag.code is already e.g. "eslint(no-debugger)" — don't wrap in parens.
+    fn(`${diag.message} ${diag.code}`, path, line);
+  }
+
+  if (failed) {
+    fail("oxlint check failed, see inline comments");
+  } else {
+    message("oxlint check success :clap:", { icon: ":white_check_mark:" });
+  }
+};

--- a/plugins/oxlint-plugin.js
+++ b/plugins/oxlint-plugin.js
@@ -49,13 +49,19 @@ exports.oxlintPlugin = async () => {
   let stdout = "";
   let stderr = "";
   try {
-    stdout = execFileSync("oxlint", ["--format=json", ...filteredFiles], {
+    stdout = execFileSync("oxlint", ["--format=json", "--", ...filteredFiles], {
       encoding: "utf8",
       env: binEnv(),
     });
   } catch (error) {
     stdout = error.stdout || "";
     stderr = error.stderr || "";
+    if (!stdout.trim()) {
+      fail(
+        `oxlint exited with no output.${stderr ? ` stderr: ${stderr.trim()}` : ""}`,
+      );
+      return;
+    }
   }
 
   let diagnostics = [];

--- a/plugins/oxlint-plugin.js
+++ b/plugins/oxlint-plugin.js
@@ -1,4 +1,4 @@
-const { execSync } = require("child_process");
+const { execFileSync } = require("child_process");
 const Path = require("path");
 
 const { git } = danger;
@@ -37,7 +37,7 @@ exports.oxlintPlugin = async () => {
 
   const filesToLint = git.created_files.concat(git.modified_files);
   const filteredFiles = filesToLint.filter(
-    (file) => !!file.match("(tsx|ts|jsx|js|mjs|cjs)$"),
+    (file) => !!file.match(/\.(tsx|ts|jsx|js|mjs|cjs)$/),
   );
 
   if (filteredFiles.length === 0) {
@@ -49,10 +49,10 @@ exports.oxlintPlugin = async () => {
   let stdout = "";
   let stderr = "";
   try {
-    stdout = execSync(
-      `oxlint --format=json ${filteredFiles.map((f) => `"${f}"`).join(" ")}`,
-      { encoding: "utf8", env: binEnv() },
-    );
+    stdout = execFileSync("oxlint", ["--format=json", ...filteredFiles], {
+      encoding: "utf8",
+      env: binEnv(),
+    });
   } catch (error) {
     stdout = error.stdout || "";
     stderr = error.stderr || "";
@@ -60,7 +60,7 @@ exports.oxlintPlugin = async () => {
 
   let diagnostics = [];
   try {
-    diagnostics = JSON.parse(stdout).diagnostics || [];
+    diagnostics = JSON.parse(stdout || "{}").diagnostics || [];
   } catch (e) {
     fail(
       `oxlint produced output that could not be parsed as JSON.${stderr ? ` stderr: ${stderr.trim()}` : ""}`,

--- a/plugins/prettier-plugin.js
+++ b/plugins/prettier-plugin.js
@@ -1,5 +1,14 @@
-const { execSync } = require("child_process");
+const { execFileSync } = require("child_process");
+const Path = require("path");
+
 const { git } = danger;
+
+// Ensure the project's local node_modules/.bin is on PATH so `prettier` resolves
+// regardless of how Danger was launched.
+const binEnv = () => ({
+  ...process.env,
+  PATH: `${Path.resolve(process.cwd(), "node_modules/.bin")}${Path.delimiter}${process.env.PATH}`,
+});
 
 /**
  * Check if Prettier is installed in the project
@@ -26,7 +35,7 @@ exports.prettierPlugin = async () => {
 
   const filesToCheck = git.created_files.concat(git.modified_files);
   const filteredFiles = filesToCheck.filter(
-    (file) => !!file.match("(tsx|ts|js|json|md|yml|yaml)$"),
+    (file) => !!file.match(/\.(tsx|ts|js|json|md|yml|yaml)$/),
   );
 
   if (filteredFiles.length === 0) {
@@ -35,15 +44,13 @@ exports.prettierPlugin = async () => {
   }
 
   try {
-    execSync(
-      `prettier --check ${filteredFiles.map((file) => `"${file}"`).join(" ")}`,
-      {
-        encoding: "utf8",
-      },
-    );
+    execFileSync("prettier", ["--check", ...filteredFiles], {
+      encoding: "utf8",
+      env: binEnv(),
+    });
     message("Prettier check success :clap:", { icon: ":white_check_mark:" });
   } catch (error) {
-    const errorLines = error.stdout.split("\n");
+    const errorLines = (error.stdout || "").split("\n");
     errorLines.forEach((line) => {
       if (line.includes("Code style issues found")) {
         fail(line);


### PR DESCRIPTION
## Why

N5 projects are migrating off ESLint + Prettier onto the oxc toolchain (oxlint + oxfmt). Two problems block that migration for repos using High Voltage:

1. **The ESLint check crashes the whole Danger run on a config-less repo.** `eslintPlugin` called `new ESLint().lintFiles()` with no guard. On ESLint 9 (flat config), a repo with no ESLint config makes `lintFiles()` throw `Could not find config file.`, which aborts the **entire** Danger run — taking down every other check. A post-migration repo hits this on every PR.
2. **There's no oxc equivalent** of the lint/format checks, so an oxc repo gets no lint/format PR feedback.

High Voltage is shared across many repos still on ESLint + Prettier, so every change had to stay fully backwards-compatible.

## What changed

- **`eslint-plugin.js`** — wrap linting in a try/catch that swallows **only** the "missing config" error (skips gracefully with a visible message) and re-throws everything else. No more whole-run crash on config-less repos.
- **`oxlint-plugin.js`** (new) — lint changed JS/TS files with `oxlint --format=json`, reporting diagnostics inline at their real `span.line`. Self-skips when oxlint isn't a project dependency.
- **`oxfmt-plugin.js`** (new) — check formatting with `oxfmt --list-different`, failing on the **exit code** (not a fragile English-string match) and listing the offending files. Self-skips when oxfmt isn't a dependency.
- **`dangerfile.js`** — schedule both new plugins alongside the existing checks.
- **Hardening across all four lint/format plugins** — run tools via `execFileSync` (no shell) so PR filenames containing shell metacharacters can't break quoting or inject commands; dot-anchor the file-extension filters; guard oxlint's `JSON.parse` against empty stdout. (Also added the local-bin PATH prepend to `prettier-plugin.js`, which incidentally fixes a latent ENOENT crash.)

## Design notes

- A repo is always a full migration — either ESLint+Prettier **or** oxc, never both — so each plugin independently self-skips when its own toolchain is absent; no mutual-exclusivity logic.
- All four plugins post a **visible, consistent** skip message.
- oxlint/oxfmt are **not** added to `package.json` — like prettier, they're detected in the consumer's `node_modules` via `require.resolve` and invoked as binaries. (`eslint` stays a hard dependency because it's `require()`d.)

## Verification

No automated test suite (this package has carried none across its 2.x life, and the plugins depend on Danger's runtime globals). Verified by integration against the **real** tools instead:

- oxlint 1.71.0 JSON shape confirmed (`labels[].span.line` present); oxfmt 0.56.0 `--list-different` confirmed to exit 1 and list files.
- Config-less repo → ESLint skips, **no crash**; config-present repo → still lints inline (backwards-compat).
- oxc fixtures → oxlint fails inline at the right line; oxfmt fails listing the unformatted file; clean files pass.
- Injection-safety: a `weird$name.js` fixture reaches oxlint literally (no shell expansion).
- End-to-end `danger local` on this config-less repo completed **without** the ESLint crash, printing the skip message.
- `package.json` / `package-lock.json` unchanged.
