### PR TITLE
ci: skip release-it npm auth pre-check (publish via token)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
     "format": "prettier --write ."
   },
   "release-it": {
+    "npm": {
+      "skipChecks": true
+    },
     "git": {
       "commitMessage": "chore: release v${version}"
     },


### PR DESCRIPTION
## Why
The 2.1.0-beta.0 release run failed at release-it's pre-publish check with **`Not authenticated with npm`** — even though the registry token is correctly configured in CI. release-it runs `npm whoami` as a pre-flight auth check, and that check returns a **false negative** with token-based auth in CI (a well-known release-it/npm interaction), aborting the release before it ever tries to publish.

## Fix
Add `"npm": { "skipChecks": true }` to the release-it config (same fix already applied to `oxc-config`).

### What `skipChecks` does
It turns off the **pre-publish sanity checks** release-it runs *before* `npm publish`:
- `npm whoami` ("are you authenticated?") ← the one giving the false negative
- registry reachability ping
- version-exists / collaborator checks

With it on, release-it **skips that pre-flight step and goes straight to `npm publish`**, using the token already configured in the CI `.npmrc`.

### What it does **not** do
- It does **not** weaken security or bypass auth — `npm publish` still authenticates with the token and **will still fail** if the token is invalid or lacks `@novemberfiveco` access. It is *not* "publish without checking credentials."
- It does **not** let a broken publish silently succeed.

### Trade-off
We lose release-it's *early, friendly* pre-flight error messages. If something is genuinely wrong (expired token, version already published), the failure now surfaces at the actual `npm publish` step with npm's own error instead of an upfront message. Acceptable — the publish itself remains the source of truth for auth.

## Impact
Single-line config change. No behavior change for consumers of the package. Unblocks the `2.1.0-beta.0` release.